### PR TITLE
54 - Improvement - AwardBadgeView - Award name should be enum

### DIFF
--- a/Steps/Model/Award.swift
+++ b/Steps/Model/Award.swift
@@ -7,23 +7,90 @@
 
 import SwiftUI
 
-struct Award {
-    let name: String
-    let description: String
-    let image: String
-}
+enum Award: String, CaseIterable {
+    case firstStep
+    case goal
+    case doubleTrouble
+    case threes
+    case perfectweek
+    case messi
+    case motivated
+    case firstGoal
+    case dreamerGoal
+    case goGetter
 
-struct AwardData {
-    static let awards = [
-        Award(name: Constants.firstStepsName, description: Constants.firstStepsDescription, image: "figure.walk"),
-        Award(name: Constants.goalName, description: Constants.goalDescription, image: "soccerball"),
-        Award(name: Constants.doubleTroubleName, description: Constants.doubleTroubleDescription, image: "figure.walk.motion"),
-        Award(name: Constants.threesName, description: Constants.threesDescription, image: "figure.dance"),
-        Award(name: Constants.perfectWeekName, description: Constants.perfectWeekDescription, image: "medal"),
-        Award(name: Constants.messiName, description: Constants.soccerFieldDescription, image: "sportscourt"),
-        Award(name: Constants.motivatedName, description: Constants.motivatedDescription, image: "checklist.unchecked"),
-        Award(name: Constants.firstGoalName, description: Constants.firstGoalDescription, image: "checkmark.seal"),
-        Award(name: Constants.dreamerGoalName, description: Constants.dreamerGoalDescription, image: "list.bullet.rectangle"),
-        Award(name: Constants.goGetterName, description: Constants.goGetterDescription, image: "text.badge.checkmark.rtl")
-    ]
+    var name: String {
+        switch self {
+        case .firstStep:
+            return Constants.firstStepsName
+        case .goal:
+            return Constants.goalName
+        case .doubleTrouble:
+            return Constants.doubleTroubleName
+        case .threes:
+            return Constants.threesName
+        case .perfectweek:
+            return Constants.perfectWeekName
+        case .messi:
+            return Constants.messiName
+        case .motivated:
+            return Constants.motivatedName
+        case .firstGoal:
+            return Constants.firstGoalName
+        case .dreamerGoal:
+            return Constants.dreamerGoalName
+        case .goGetter:
+            return Constants.goGetterName
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .firstStep:
+            return Constants.firstStepsDescription
+        case .goal:
+            return Constants.goalDescription
+        case .doubleTrouble:
+            return Constants.doubleTroubleDescription
+        case .threes:
+            return Constants.threesDescription
+        case .perfectweek:
+            return Constants.perfectWeekDescription
+        case .messi:
+            return Constants.soccerFieldDescription
+        case .motivated:
+            return Constants.motivatedDescription
+        case .firstGoal:
+            return Constants.firstGoalDescription
+        case .dreamerGoal:
+            return Constants.dreamerGoalDescription
+        case .goGetter:
+            return Constants.goGetterDescription
+        }
+    }
+
+    var image: String {
+        switch self {
+        case .firstStep:
+            return "figure.walk"
+        case .goal:
+            return "soccerball"
+        case .doubleTrouble:
+            return "figure.walk.motion"
+        case .threes:
+            return "figure.dance"
+        case .perfectweek:
+            return "medal"
+        case .messi:
+            return "sportscourt"
+        case .motivated:
+            return "checklist.unchecked"
+        case .firstGoal:
+            return "checkmark.seal"
+        case .dreamerGoal:
+            return "list.bullet.rectangle"
+        case .goGetter:
+            return "text.badge.checkmark.rtl"
+        }
+    }
 }

--- a/Steps/Screens/AwardDetailView.swift
+++ b/Steps/Screens/AwardDetailView.swift
@@ -46,6 +46,6 @@ struct AwardDetailView: View {
 
 struct AwardDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        AwardDetailView(award: AwardData.awards[1], viewModel: StepsViewModel())
+        AwardDetailView(award: .goal, viewModel: StepsViewModel())
     }
 }

--- a/Steps/Screens/AwardView.swift
+++ b/Steps/Screens/AwardView.swift
@@ -23,7 +23,7 @@ struct AwardView: View {
                     .padding()
 
                 LazyVGrid(columns: columns) {
-                    ForEach(AwardData.awards, id: \.name) { award in
+                    ForEach(Award.allCases, id: \.name) { award in
                         AwardBadgeView(award: award, viewModel: viewModel)
                     }
                 }

--- a/Steps/Views/AwardBadgeView.swift
+++ b/Steps/Views/AwardBadgeView.swift
@@ -15,27 +15,27 @@ struct AwardBadgeView: View {
         sortDescriptors: []) var tasks: FetchedResults<Task>
 
     var isAwardUnlocked: Bool {
-        switch award.name {
-        case Constants.firstStepsName:
+        switch award {
+        case .firstStep:
             return viewModel.steps.contains { $0.count > 100 }
-        case Constants.goalName:
+        case .goal:
             return viewModel.steps.contains { $0.count >= viewModel.goal }
-        case Constants.doubleTroubleName:
+        case .doubleTrouble:
             return viewModel.steps.contains { $0.count >= (viewModel.goal * 2)}
-        case Constants.threesName:
+        case .threes:
             return viewModel.steps.contains { $0.count >= (viewModel.goal * 3)}
-        case Constants.perfectWeekName:
+        case .perfectweek:
             if viewModel.steps.count == 0 { return false }
             return viewModel.steps.allSatisfy { $0.count > viewModel.goal }
-        case Constants.messiName:
+        case .messi:
             return viewModel.steps.contains { $0.count >= 14400 } // about 100 soccer fields
-        case Constants.motivatedName:
+        case .motivated:
             return tasks.count > 1
-        case Constants.firstGoalName:
+        case .firstGoal:
             return tasks.count > 1 && tasks.last?.isComplete == true
-        case Constants.dreamerGoalName:
+        case .dreamerGoal:
             return tasks.count > 4
-        case Constants.goGetterName:
+        case .goGetter:
             var completed = 0
             for task in tasks {
                 if task.isComplete {
@@ -67,6 +67,6 @@ struct AwardBadgeView: View {
 
 struct AwardBadgeView_Previews: PreviewProvider {
     static var previews: some View {
-        AwardBadgeView(award: AwardData.awards[4], viewModel: StepsViewModel())
+        AwardBadgeView(award: .perfectweek, viewModel: StepsViewModel())
     }
 }

--- a/Steps/Views/BadgeImageView.swift
+++ b/Steps/Views/BadgeImageView.swift
@@ -25,6 +25,6 @@ struct BadgeImageView: View {
 
 struct BadgeImageView_Previews: PreviewProvider {
     static var previews: some View {
-        BadgeImageView(award: AwardData.awards[0])
+        BadgeImageView(award: .firstStep)
     }
 }


### PR DESCRIPTION
Improvement:
54 - Improvement - AwardBadgeView - Award name should be enum

Details:
Replaced ```Award``` struct with ```Award``` enum
No need of ```AwardData```