### PR TITLE
Customizable Home Screen background

### DIFF
--- a/Steps.xcodeproj/project.pbxproj
+++ b/Steps.xcodeproj/project.pbxproj
@@ -61,6 +61,13 @@
 		18F27C0B2ACBD26B00413DB4 /* StepsConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 18F27C092ACBD26B00413DB4 /* StepsConfig.xcconfig */; };
 		18F27C0D2ACBD2F500413DB4 /* StepsConfigTemplate.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 18F27C0C2ACBD2F500413DB4 /* StepsConfigTemplate.xcconfig */; };
 		18F27C0E2ACBD2F500413DB4 /* StepsConfigTemplate.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 18F27C0C2ACBD2F500413DB4 /* StepsConfigTemplate.xcconfig */; };
+		64B742A12AD5C79500811110 /* FileManager+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A02AD5C79500811110 /* FileManager+Ext.swift */; };
+		64B742A22AD5C79500811110 /* FileManager+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A02AD5C79500811110 /* FileManager+Ext.swift */; };
+		64B742A42AD5C7B300811110 /* UIImage+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A32AD5C7B300811110 /* UIImage+Ext.swift */; };
+		64B742A52AD5C7B300811110 /* UIImage+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A32AD5C7B300811110 /* UIImage+Ext.swift */; };
+		64B742A72AD5C7CF00811110 /* ImageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A62AD5C7CF00811110 /* ImageStorage.swift */; };
+		64B742A82AD5C7CF00811110 /* ImageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A62AD5C7CF00811110 /* ImageStorage.swift */; };
+		64B742AA2AD5C7F000811110 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B742A92AD5C7F000811110 /* BackgroundView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,6 +146,10 @@
 		18F1F9E42956362E00156D4C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		18F27C092ACBD26B00413DB4 /* StepsConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StepsConfig.xcconfig; sourceTree = "<group>"; };
 		18F27C0C2ACBD2F500413DB4 /* StepsConfigTemplate.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StepsConfigTemplate.xcconfig; sourceTree = "<group>"; };
+		64B742A02AD5C79500811110 /* FileManager+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Ext.swift"; sourceTree = "<group>"; };
+		64B742A32AD5C7B300811110 /* UIImage+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Ext.swift"; sourceTree = "<group>"; };
+		64B742A62AD5C7CF00811110 /* ImageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStorage.swift; sourceTree = "<group>"; };
+		64B742A92AD5C7F000811110 /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,6 +186,8 @@
 			isa = PBXGroup;
 			children = (
 				18A1FB1A294AAB93009B87EF /* Date+Ext.swift */,
+				64B742A02AD5C79500811110 /* FileManager+Ext.swift */,
+				64B742A32AD5C7B300811110 /* UIImage+Ext.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -271,6 +284,7 @@
 				185B74CE295CEA02000AD18A /* CurrentStepsCardView.swift */,
 				1838FC20296A7E8A00EAA116 /* AddTaskView.swift */,
 				1838FC22296A846200EAA116 /* TaskListRowView.swift */,
+				64B742A92AD5C7F000811110 /* BackgroundView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -302,6 +316,7 @@
 			children = (
 				1838FC24296A85D700EAA116 /* Extensions */,
 				18F1F9E42956362E00156D4C /* Constants.swift */,
+				64B742A62AD5C7CF00811110 /* ImageStorage.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -434,6 +449,7 @@
 				185DB3F929494947003BCC48 /* AwardView.swift in Sources */,
 				18C81E16294A934B0058138F /* StepsViewModel.swift in Sources */,
 				185B74CF295CEA02000AD18A /* CurrentStepsCardView.swift in Sources */,
+				64B742A12AD5C79500811110 /* FileManager+Ext.swift in Sources */,
 				181AE8682953B83000BAD40D /* AwardLockedView.swift in Sources */,
 				189BDCF4294D3E1100E8237F /* AwardBadgeView.swift in Sources */,
 				18E37432294E91B100D6B253 /* EditStepsGoalView.swift in Sources */,
@@ -445,9 +461,12 @@
 				181AE8662953AB9800BAD40D /* AwardDetailView.swift in Sources */,
 				188042D429527BD700E14D9D /* SettingsViewModel.swift in Sources */,
 				1838FC19296A785E00EAA116 /* TaskView.swift in Sources */,
+				64B742AA2AD5C7F000811110 /* BackgroundView.swift in Sources */,
 				18E3D95D2AD4C06D00E33E0F /* NewWeekStepsView.swift in Sources */,
+				64B742A42AD5C7B300811110 /* UIImage+Ext.swift in Sources */,
 				18F1F9E52956362E00156D4C /* Constants.swift in Sources */,
 				1838FC23296A846200EAA116 /* TaskListRowView.swift in Sources */,
+				64B742A72AD5C7CF00811110 /* ImageStorage.swift in Sources */,
 				18C81E14294A923B0058138F /* StepsDetailView.swift in Sources */,
 				18E37434294E925100D6B253 /* StepsGoalCardView.swift in Sources */,
 				189BDCEA294D163700E8237F /* FactView.swift in Sources */,
@@ -473,7 +492,10 @@
 				185F75DE295E1A5100F48560 /* Step.swift in Sources */,
 				185DB40A2949514D003BCC48 /* StepsWidget.swift in Sources */,
 				185F75DD295E1A4200F48560 /* Date+Ext.swift in Sources */,
+				64B742A52AD5C7B300811110 /* UIImage+Ext.swift in Sources */,
+				64B742A82AD5C7CF00811110 /* ImageStorage.swift in Sources */,
 				185F75DF295E1A5400F48560 /* Constants.swift in Sources */,
+				64B742A22AD5C79500811110 /* FileManager+Ext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Steps/Screens/SettingsView.swift
+++ b/Steps/Screens/SettingsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import UserNotifications
+import PhotosUI
 
 struct SettingsView: View {
     @StateObject var viewModel = SettingsViewModel()
@@ -23,6 +24,24 @@ struct SettingsView: View {
                         Toggle(Constants.notifications, isOn: $viewModel.notificationsOn)
                     } header: {
                         Label(Constants.notificationSettings, systemImage: "bell")
+                    }
+                    
+                    Section {
+                        if stepsViewModel.backgroundImage != nil {
+                            Button("Reset background image") {
+                                stepsViewModel.backgroundImageSelection = nil
+                            }
+                            .buttonStyle(.borderless)
+                        } else {
+                            PhotosPicker(selection: $stepsViewModel.backgroundImageSelection,
+                                         matching: .images,
+                                         photoLibrary: .shared()) {
+                                Text("Set background image")
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    } header: {
+                        Label("Home Screen", systemImage: "iphone.gen3")
                     }
 
                     Link(Constants.termsOfUse, destination: URL(string: Constants.termsURL)!)
@@ -41,6 +60,10 @@ struct SettingsView: View {
             })
             .navigationTitle("⚙️ \(Constants.settingsTitle)")
             .tint(.indigo)
+        }
+        .alert(isPresented: $stepsViewModel.showBackgroundImageAlert) {
+            Alert(title: Text("Failed to set background image."),
+                              message: Text("Please choose another image."))
         }
     }
 }

--- a/Steps/Utilities/Constants.swift
+++ b/Steps/Utilities/Constants.swift
@@ -15,6 +15,7 @@ struct Constants {
     // MARK: Messages
     static let goalKey = "goal"
     static let notificationKey = "notifications"
+    static let backgroundImageKey = "backgroundImage"
     static let steps = "Steps"
     static let weeklySteps = "Weekly Steps"
     static let goal = "Goal"

--- a/Steps/Utilities/Extensions/FileManager+Ext.swift
+++ b/Steps/Utilities/Extensions/FileManager+Ext.swift
@@ -1,0 +1,15 @@
+//
+//  FileManager+Ext.swift
+//  Steps
+//
+//  Created by Raphael on 05.10.23.
+//
+
+import Foundation
+
+extension FileManager {
+    func documentsDirectory() -> URL {
+        let path = urls(for: .documentDirectory, in: .userDomainMask)
+        return path.first!
+    }
+}

--- a/Steps/Utilities/Extensions/UIImage+Ext.swift
+++ b/Steps/Utilities/Extensions/UIImage+Ext.swift
@@ -1,0 +1,18 @@
+//
+//  UIImage+Ext.swift
+//  Steps
+//
+//  Created by Raphael on 05.10.23.
+//
+
+import SwiftUI
+
+extension UIImage {
+    func png(isOpaque: Bool = true) -> Data? { flattened(isOpaque: isOpaque).pngData() }
+    func flattened(isOpaque: Bool = true) -> UIImage {
+        if imageOrientation == .up { return self }
+        let format = imageRendererFormat
+        format.opaque = isOpaque
+        return UIGraphicsImageRenderer(size: size, format: format).image { _ in draw(at: .zero) }
+    }
+}

--- a/Steps/Utilities/ImageStorage.swift
+++ b/Steps/Utilities/ImageStorage.swift
@@ -1,0 +1,31 @@
+//
+//  ImageStorage.swift
+//  Steps
+//
+//  Created by Raphael on 05.10.23.
+//
+
+import SwiftUI
+
+func saveImage(image: UIImage, key: String) {
+    let path = FileManager.default.documentsDirectory()
+        .appendingPathComponent(key)
+        .appendingPathExtension("png")
+    if let pngData = image.png() {
+        try? pngData.write(to: path)
+    }
+}
+
+func loadImage(key: String) -> UIImage? {
+    let path = FileManager.default.documentsDirectory()
+        .appendingPathComponent(key)
+        .appendingPathExtension("png")
+    return UIImage(contentsOfFile: path.path())
+}
+
+func deleteImage(key: String) {
+    let path = FileManager.default.documentsDirectory()
+        .appendingPathComponent(key)
+        .appendingPathExtension("png")
+    try? FileManager.default.removeItem(at: path)
+}

--- a/Steps/Views/BackgroundView.swift
+++ b/Steps/Views/BackgroundView.swift
@@ -1,0 +1,22 @@
+//
+//  BackgroundView.swift
+//  Steps
+//
+//  Created by Raphael on 04.10.23.
+//
+
+import SwiftUI
+
+struct BackgroundView: View {
+    @ObservedObject var stepsModel: StepsViewModel
+
+    var body: some View {
+        if let backgroundImage = stepsModel.backgroundImage {
+            Image(uiImage: backgroundImage)
+                .resizable()
+        } else {
+            Image("background")
+                .resizable()
+        }
+    }
+}

--- a/Steps/Views/MountainView.swift
+++ b/Steps/Views/MountainView.swift
@@ -13,9 +13,7 @@ struct MountainView: View {
     var body: some View {
         GeometryReader { geo in
             ZStack {
-                Image("background")
-                    .resizable()
-                    .frame(width: geo.size.width, height: geo.size.height)
+                BackgroundView(stepsModel: viewModel)
                     .aspectRatio(contentMode: .fill)
                     .edgesIgnoringSafeArea(.all)
                     .opacity(0.5)


### PR DESCRIPTION
### Issue 29: Ability for users to add their own image as Home Screen background

- Adds new section in the settings to select a photo to set as the background.
  - If the image is set if can be reset to the default image.
- This is realized via a `PhotosPicker` that asynchronously loads the image, compare this [sample code](https://developer.apple.com/documentation/photokit/bringing_photos_picker_to_your_swiftui_app).
- Adds functions to save, load, and delete a `UIImage` with a given `key` via `FileManager`.

Ok, I reset my branch to `dev`, which closed the previous PR I think, and applied my changes again. I hope there are not conflicts now.