### PR TITLE
#73 Fix redundant goal setting in StepsViewModel

### DIFF
--- a/Steps/ViewModel/StepsViewModel.swift
+++ b/Steps/ViewModel/StepsViewModel.swift
@@ -36,15 +36,9 @@ class StepsViewModel: ObservableObject {
     @Published var totalDistance: [Distance] = []
     
     @Published var steps: [Step] = []
-    @Published var goal: Int = 10_000 {
-        didSet {
-            self.userDefaults.set(goal, forKey: Constants.goalKey)
-        }
-    }
+    @AppStorage(Constants.goalKey, store: .appGroup) var goal: Int = 10_000
 
     init() {
-        self.goal = self.userDefaults.integer(forKey: Constants.goalKey) ?? 10_000
-
         if HKHealthStore.isHealthDataAvailable() {
             healthStore = HKHealthStore()
         }

--- a/StepsTests/StepsTests.swift
+++ b/StepsTests/StepsTests.swift
@@ -32,11 +32,13 @@ final class StepsTests: XCTestCase {
     
     // TODO: Test @AppStorage 
     func testUserDefaults() async {
-
+        let newGoal = 1_234
+        
         let vm = StepsViewModel()
-        vm.goal = 1_234
-        @Dependency(\.userDefaults) var userDefaults
-        XCTAssertEqual(1_234, userDefaults.integer(forKey: Constants.goalKey))
+        vm.goal = newGoal
+        
+        let resultGoal = UserDefaults.appGroup?.value(forKey: Constants.goalKey) as? Int
+        XCTAssertEqual(newGoal, resultGoal)
             
         
 // Not sure yet how to inject UserDefaults dependency into @AppStorage.


### PR DESCRIPTION
Issue #73: Set default steps goal to 10,000

Details:
 - Use AppStorage with `UserDefaults.appGroup` to remove redundant goal setting in init of StepsViewModel
 - Update unit test for setting goal