### PR TITLE
fixes chart's duplicate labels

### DIFF
--- a/Steps/ViewModel/StepsViewModel.swift
+++ b/Steps/ViewModel/StepsViewModel.swift
@@ -197,6 +197,12 @@ class StepsViewModel: ObservableObject {
     func updateUIFromStats(_ statsCollection: HKStatisticsCollection) {
         let startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         let endDate = Date()
+        
+        // Clear the array before enumerating
+        DispatchQueue.main.async {
+            self.steps.removeAll()
+        }
+        
         statsCollection.enumerateStatistics(from: startDate, to: endDate) { stats, stop in
             let count = stats.sumQuantity()?.doubleValue(for: .count())
             let step = Step(count: Int(count ?? 0), date: stats.startDate)


### PR DESCRIPTION
In this PR I have added a fix for the duplicate chart labels. 
I've added a code to empty the steps array before adding steps. 

![Screenshot 2024-02-03 at 23 27 59](https://github.com/brittanyarima/Steps/assets/25651879/7d1fafb2-d3cf-482d-96cc-08267ca23e7e)
